### PR TITLE
added minimum required node/npm version

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,10 @@
     "url": "https://github.com/aether7/fa-storage/issues"
   },
   "homepage": "https://github.com/aether7/fa-storage#readme",
+  "engines": {
+    "node": ">= 8.0.0",
+    "npm": ">= 5.0.0"
+  },
   "devDependencies": {
     "html-webpack-plugin": "^2.30.1",
     "webpack": "^3.4.1",


### PR DESCRIPTION
Because with those restrictions we are able to work with many new stuff, specially with new syntax of JS on node